### PR TITLE
support php 8.0

### DIFF
--- a/classes/ArrayMemoryStorage.php
+++ b/classes/ArrayMemoryStorage.php
@@ -110,7 +110,7 @@ class ArrayMemoryStorage
         }
 
         $this->memory = shm_attach($this->key, $this->getMemSize());
-        if (!is_resource($this->memory)) {
+        if ($this->memory === false) {
             throw new \Exception("Failed to attach to shared memory.");
         }
     }


### PR DESCRIPTION
shm_attach - function returns an SysvSharedMemory instance now; previously, a resource was returned.